### PR TITLE
Added manual save command

### DIFF
--- a/scripting/chud-commands.sp
+++ b/scripting/chud-commands.sp
@@ -2,6 +2,7 @@ public void CreateCMDS()
 {
     //COMMANDS
     RegConsoleCmd("sm_chud", CHUD_MainMenu, "[Clean HUD] Opens main menu");
+    RegConsoleCmd("sm_chud_save", CHUD_Save, "[Clean HUD] Saves client settings to database");
     //TODO
     RegConsoleCmd("sm_chud_export", Client_Export, "[Clean HUD] Export Settings");
     RegConsoleCmd("sm_chud_import", Client_Import, "[Clean HUD] Import Settings");
@@ -95,4 +96,15 @@ public Action Client_Export(int client, int args)
     */
 
     return Plugin_Handled;
+}
+
+public Action CHUD_Save(int client, int args)
+{
+	if (!IsValidClient(client) || IsFakeClient(client))
+		return Plugin_Handled;
+
+	CPrintToChat(client, "%t", "Settings_Save");
+	db_SET_OPTIONS(client);
+
+	return Plugin_Handled;
 }

--- a/scripting/chud-globals.sp
+++ b/scripting/chud-globals.sp
@@ -78,7 +78,7 @@ float g_fTickrate;
 
 char g_szSteamID[MAXPLAYERS + 1][32];
 
-//EEDITING
+//EDITING
 /*
 0 - CSD
 1 - KEYS

--- a/translations/cleanhud.phrases.txt
+++ b/translations/cleanhud.phrases.txt
@@ -31,4 +31,8 @@
 	{
 		"en"		"{red}CHUD | {default}Exported All the Settings. Open {red}console{default} to get the code!"
 	}
+	"Settings_Save"
+	{
+		"en"		"{red}CHUD | {green}Settings saved!"
+	}
 }


### PR DESCRIPTION
- Added a basic, manual !chud_save command. 
- Added line in translation file to print to clients that their settings saved.
- Fixed a comment typo.

I'm not sure how necessary this change is as the save on disconnect works fine and save on map change when the map time runs out works, but RTV map changes and full client quits while in game did not seem to save. The command was just my simple solution to ensure client settings save before either case. Probably makes more sense to add saves for those conditions/clauses/whatnot but admittedly that's beyond me.